### PR TITLE
LUCENE-8215: Fix several fragile exception handling places in o.a.l.index

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ConcurrentMergeScheduler.java
@@ -418,7 +418,8 @@ public class ConcurrentMergeScheduler extends MergeScheduler {
         if (value != null) {
           spins = Boolean.parseBoolean(value);
         }
-      } catch (Throwable ignored) {
+      } catch (Exception ignored) {
+        // that's fine we might hit a SecurityException etc. here just continue
       }
       setDefaultMaxMergesAndThreads(spins);
       if (verbose()) {

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -636,8 +636,8 @@ final class DocumentsWriterFlushControl implements Accountable {
         try {
           documentsWriter.subtractFlushedNumDocs(dwpt.getNumDocsInRAM());
           dwpt.abort();
-        } catch (Throwable ex) {
-          // ignore - keep on aborting the flush queue
+        } catch (Exception ex) {
+          // that's fine we just abort everything here this is best effort
         } finally {
           doAfterFlush(dwpt);
         }
@@ -647,8 +647,8 @@ final class DocumentsWriterFlushControl implements Accountable {
           flushingWriters.put(blockedFlush.dwpt, Long.valueOf(blockedFlush.bytes));
           documentsWriter.subtractFlushedNumDocs(blockedFlush.dwpt.getNumDocsInRAM());
           blockedFlush.dwpt.abort();
-        } catch (Throwable ex) {
-          // ignore - keep on aborting the blocked queue
+        } catch (Exception ex) {
+          // that's fine we just abort everything here this is best effort
         } finally {
           doAfterFlush(blockedFlush.dwpt);
         }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
@@ -356,10 +356,6 @@ final class IndexFileDeleter implements Closeable {
     }
   }
 
-  public SegmentInfos getLastSegmentInfos() {
-    return lastSegmentInfos;
-  }
-
   /**
    * Remove the CommitPoints in the commitsToDelete List by
    * DecRef'ing all files from each SegmentInfos.
@@ -381,9 +377,7 @@ final class IndexFileDeleter implements Closeable {
         try {
           decRef(commit.files);
         } catch (Throwable t) {
-          if (firstThrowable == null) {
-            firstThrowable = t;
-          }
+          firstThrowable = IOUtils.useOrSuppress(firstThrowable, t);
         }
       }
       commitsToDelete.clear();
@@ -583,20 +577,14 @@ final class IndexFileDeleter implements Closeable {
           toDelete.add(file);
         }
       } catch (Throwable t) {
-        if (firstThrowable == null) {
-          // Save first exception and throw it in the end, but be sure to finish decRef all files
-          firstThrowable = t;
-        }
+        firstThrowable = IOUtils.useOrSuppress(firstThrowable, t);
       }
     }
 
     try {
       deleteFiles(toDelete);
     } catch (Throwable t) {
-      if (firstThrowable == null) {
-        // Save first exception and throw it in the end, but be sure to finish decRef all files
-        firstThrowable = t;
-      }
+      firstThrowable = IOUtils.useOrSuppress(firstThrowable, t);
     }
 
     if (firstThrowable != null) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2586,6 +2586,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable {
    * @return The <a href="#sequence_number">sequence number</a>
    * for this operation
    */
+  @SuppressWarnings("try")
   public long deleteAll() throws IOException {
     ensureOpen();
     // Remove any buffered docs
@@ -2604,7 +2605,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable {
      */
     try {
       synchronized (fullFlushLock) {
-        try (Closeable release = docWriter.lockAndAbortAll(this)) {
+        try (Closeable finalizer = docWriter.lockAndAbortAll(this)) {
           processEvents(false);
           synchronized (this) {
             try {
@@ -3957,6 +3958,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable {
     return mergedDeletesAndUpdates;
   }
 
+  @SuppressWarnings("try")
   synchronized private boolean commitMerge(MergePolicy.OneMerge merge, MergeState mergeState) throws IOException {
 
     testPoint("startCommitMerge");
@@ -4069,22 +4071,11 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable {
       deleteNewFiles(merge.info.files());
     }
 
-    try {
+    try (Closeable finalizer = this::checkpoint) {
       // Must close before checkpoint, otherwise IFD won't be
       // able to delete the held-open files from the merge
       // readers:
       closeMergeReaders(merge, false);
-      checkpoint();
-    } catch (Throwable t) {
-      // Must note the change to segmentInfos so any commits
-      // in-flight don't lose it (IFD will incRef/protect the
-      // new files we created):
-      try {
-        checkpoint();
-      } catch (Throwable t1) {
-        t.addSuppressed(t1);
-      }
-      throw t;
     }
 
     if (infoStream.isEnabled("IW")) {
@@ -4403,45 +4394,27 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable {
     runningMerges.remove(merge);
   }
 
-  private final synchronized void closeMergeReaders(MergePolicy.OneMerge merge, boolean suppressExceptions) throws IOException {
-    final int numSegments = merge.readers.size();
-    Throwable th = null;
-
-    boolean drop = suppressExceptions == false;
-    
-    for (int i = 0; i < numSegments; i++) {
-      final SegmentReader sr = merge.readers.get(i);
-      if (sr != null) {
-        try {
-          final ReadersAndUpdates rld = readerPool.get(sr.getSegmentInfo(), false);
-          // We still hold a ref so it should not have been removed:
-          assert rld != null;
-          if (drop) {
-            rld.dropChanges();
-          } else {
-            rld.dropMergingUpdates();
-          }
-          rld.release(sr);
-          readerPool.release(rld);
-          if (drop) {
-            readerPool.drop(rld.info);
-          }
-        } catch (Throwable t) {
-          th = IOUtils.useOrSuppress(th, t);
+  @SuppressWarnings("try")
+  private synchronized void closeMergeReaders(MergePolicy.OneMerge merge, boolean suppressExceptions) throws IOException {
+    final boolean drop = suppressExceptions == false;
+    try (Closeable finalizer = merge::mergeFinished) {
+      IOUtils.applyToAll(merge.readers, sr -> {
+        final ReadersAndUpdates rld = readerPool.get(sr.getSegmentInfo(), false);
+        // We still hold a ref so it should not have been removed:
+        assert rld != null;
+        if (drop) {
+          rld.dropChanges();
+        } else {
+          rld.dropMergingUpdates();
         }
-        merge.readers.set(i, null);
-      }
-    }
-
-    try {
-      merge.mergeFinished();
-    } catch (Throwable t) {
-      th = IOUtils.useOrSuppress(th, t);
-    }
-    
-    // If any error occurred, throw it.
-    if (!suppressExceptions && th != null) {
-      throw IOUtils.rethrowAlways(th);
+        rld.release(sr);
+        readerPool.release(rld);
+        if (drop) {
+          readerPool.drop(rld.info);
+        }
+      });
+    } finally {
+      Collections.fill(merge.readers, null);
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -845,7 +845,7 @@ class ReadersAndUpdates {
         success = true;
       } finally {
         if (success == false) {
-          newReader.decRef();
+          newReader.close();
         }
       }
       reader = newReader;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValues.java
@@ -78,21 +78,10 @@ final class SegmentDocValues {
    * generations. 
    */
   synchronized void decRef(List<Long> dvProducersGens) throws IOException {
-    Throwable t = null;
-    for (Long gen : dvProducersGens) {
+    IOUtils.applyToAll(dvProducersGens, gen -> {
       RefCount<DocValuesProducer> dvp = genDVProducers.get(gen);
       assert dvp != null : "gen=" + gen;
-      try {
-        dvp.decRef();
-      } catch (Throwable th) {
-        if (t == null) {
-          t = th;
-        }
-      }
-    }
-
-    if (t != null) {
-      throw IOUtils.rethrowAlways(t);
-    }
+      dvp.decRef();
+    });
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentDocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentDocValuesProducer.java
@@ -55,7 +55,6 @@ class SegmentDocValuesProducer extends DocValuesProducer {
    * @param segDocValues producer map
    */
   SegmentDocValuesProducer(SegmentCommitInfo si, Directory dir, FieldInfos coreInfos, FieldInfos allInfos, SegmentDocValues segDocValues) throws IOException {
-    boolean success = false;
     try {
       DocValuesProducer baseProducer = null;
       for (FieldInfo fi : allInfos) {
@@ -74,21 +73,19 @@ class SegmentDocValuesProducer extends DocValuesProducer {
         } else {
           assert !dvGens.contains(docValuesGen);
           // otherwise, producer sees only the one fieldinfo it wrote
-          final DocValuesProducer dvp = segDocValues.getDocValuesProducer(docValuesGen, si, dir, new FieldInfos(new FieldInfo[] { fi }));
+          final DocValuesProducer dvp = segDocValues.getDocValuesProducer(docValuesGen, si, dir, new FieldInfos(new FieldInfo[]{fi}));
           dvGens.add(docValuesGen);
           dvProducers.add(dvp);
           dvProducersByField.put(fi.name, dvp);
         }
       }
-      success = true;
-    } finally {
-      if (success == false) {
-        try {
-          segDocValues.decRef(dvGens);
-        } catch (Throwable t) {
-          // Ignore so we keep throwing first exception
-        }
+    } catch (Throwable t) {
+      try {
+        segDocValues.decRef(dvGens);
+      } catch (Throwable t1) {
+        t.addSuppressed(t1);
       }
+      throw t;
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
@@ -297,23 +297,9 @@ public final class SegmentReader extends CodecReader {
   private final Set<ClosedListener> readerClosedListeners = new CopyOnWriteArraySet<>();
 
   @Override
-  void notifyReaderClosedListeners(Throwable th) throws IOException {
+  void notifyReaderClosedListeners() throws IOException {
     synchronized(readerClosedListeners) {
-      for(ClosedListener listener : readerClosedListeners) {
-        try {
-          listener.onClose(readerCacheHelper.getKey());
-        } catch (Throwable t) {
-          if (th == null) {
-            th = t;
-          } else {
-            th.addSuppressed(t);
-          }
-        }
-      }
-      
-      if (th != null) {
-        IOUtils.rethrowAlways(th);
-      }
+      IOUtils.applyToAll(readerClosedListeners, l -> l.onClose(readerCacheHelper.getKey()));
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/TwoPhaseCommitTool.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TwoPhaseCommitTool.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 import java.io.IOException;
 
 
+
 /**
  * A utility for executing 2-phase commit on several objects.
  * 

--- a/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IOUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.util;
 
-
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -40,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -637,5 +637,25 @@ public final class IOUtils {
       first.addSuppressed(second);
     }
     return first;
+  }
+
+  /**
+   * Applies the consumer to all non-null elements in the collection even if an exception is thrown. The first exception
+   * thrown by the consumer is re-thrown and subsequent exceptions are suppressed.
+   */
+  public static <T> void applyToAll(Collection<T> collection, IOConsumer<T> consumer) throws IOException {
+    IOUtils.close(collection.stream().filter(Objects::nonNull).map(t -> (Closeable) () -> consumer.accept(t))::iterator);
+  }
+
+  /**
+   * An IO operation with a single input.
+   * @see java.util.function.Consumer
+   */
+  @FunctionalInterface
+  public interface IOConsumer<T> {
+    /**
+     * Performs this operation on the given argument.
+     */
+    void accept(T input) throws IOException;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIOUtils.java
@@ -27,6 +27,8 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileStoreAttributeView;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -485,6 +487,21 @@ public class TestIOUtils extends LuceneTestCase {
     }
     IOUtils.fsync(somefile, false);
     // no exception
+  }
+
+  public void testApplyToAll() {
+    ArrayList<Integer> closed = new ArrayList<>();
+    RuntimeException runtimeException = expectThrows(RuntimeException.class, () ->
+        IOUtils.applyToAll(Arrays.asList(1, 2), i -> {
+          closed.add(i);
+          throw new RuntimeException("" + i);
+        }));
+    assertEquals("1", runtimeException.getMessage());
+    assertEquals(1, runtimeException.getSuppressed().length);
+    assertEquals("2", runtimeException.getSuppressed()[0].getMessage());
+    assertEquals(2, closed.size());
+    assertEquals(1, closed.get(0).intValue());
+    assertEquals(2, closed.get(1).intValue());
   }
 
 }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/OwnCacheKeyMultiReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/OwnCacheKeyMultiReader.java
@@ -57,23 +57,9 @@ public final class OwnCacheKeyMultiReader extends MultiReader {
   }
 
   @Override
-  void notifyReaderClosedListeners(Throwable th) throws IOException {
+  void notifyReaderClosedListeners() throws IOException {
     synchronized(readerClosedListeners) {
-      for(ClosedListener listener : readerClosedListeners) {
-        try {
-          listener.onClose(cacheHelper.getKey());
-        } catch (Throwable t) {
-          if (th == null) {
-            th = t;
-          } else {
-            th.addSuppressed(t);
-          }
-        }
-      }
-      
-      if (th != null) {
-        throw IOUtils.rethrowAlways(th);
-      }
+      IOUtils.applyToAll(readerClosedListeners, l -> l.onClose(cacheHelper.getKey()));
     }
   }
 


### PR DESCRIPTION
Several places in the index package don't handle exceptions well or ignores them.
This change adds some utility methods and cuts over to make use of try/with blocks
to simplify exception handling.